### PR TITLE
Leave ownership of postfix config files with root

### DIFF
--- a/dovecot/Dockerfile
+++ b/dovecot/Dockerfile
@@ -29,9 +29,6 @@ RUN mkdir /etc/postfix/tmp; awk < /etc/postfix/virtual '{ print $2 }' > /etc/pos
 RUN sed -r 's,(.+)@(.+),\2/\1/,' /etc/postfix/tmp/virtual-receivers > /etc/postfix/tmp/virtual-receiver-folders
 RUN paste /etc/postfix/tmp/virtual-receivers /etc/postfix/tmp/virtual-receiver-folders > /etc/postfix/virtual-mailbox-maps
 
-# give postfix the ownership of his files
-RUN chown -R postfix:postfix /etc/postfix
-
 # map virtual aliases and user/filesystem mappings
 RUN postmap /etc/postfix/virtual
 RUN postmap /etc/postfix/virtual-mailbox-maps


### PR DESCRIPTION
Hi, and thanks for the repository.

According to the postfix documentation both the `main.cf` and `master.cf` files [should be owned by root](http://www.postfix.org/BASIC_CONFIGURATION_README.html#syntax).
Furthermore, running `postfix check` in the running dovecot container returns the following warnings:

```
postfix/postfix-script: warning: not owned by root: /etc/postfix
postfix/postfix-script: warning: not owned by root: /etc/postfix/dynamicmaps.cf
postfix/postfix-script: warning: not owned by root: /etc/postfix/main.cf
postfix/postfix-script: warning: not owned by root: /etc/postfix/master-additional.cf
postfix/postfix-script: warning: not owned by root: /etc/postfix/master.cf
postfix/postfix-script: warning: not owned by root: /etc/postfix/post-install
postfix/postfix-script: warning: not owned by root: /etc/postfix/postfix-files
postfix/postfix-script: warning: not owned by root: /etc/postfix/postfix-script
postfix/postfix-script: warning: not owned by root: /etc/postfix/sasl
```

Removing the line in the Dockerfile which gives the postfix user ownership of the files in `/etc/postfix` results in the following set of permissions/ownership:

```
-rw-r--r-- 1 root root   274 Nov 30 06:39 dynamicmaps.cf
-rw-r--r-- 1 root root  2478 Nov 30 02:43 main.cf
-rw-r--r-- 1 root root   757 Nov 30 02:43 master-additional.cf
-rw-r--r-- 1 root root  6825 Nov 30 06:39 master.cf
-rwxr-xr-x 1 root root 28047 Feb 12  2014 post-install
-rw-r--r-- 1 root root 20281 Feb 12  2014 postfix-files
-rwxr-xr-x 1 root root  8861 Feb 12  2014 postfix-script
drwxr-xr-x 1 root root     0 Feb 12  2014 sasl
drwxr-xr-x 1 root root    82 Nov 30 06:40 tmp
-rw-r--r-- 1 root root    72 Nov 30 06:39 virtual
-rw-r--r-- 1 root root    12 Nov 30 06:39 virtual-mailbox-domains
-rw-r--r-- 1 root root    82 Nov 30 06:40 virtual-mailbox-maps
-rw-r--r-- 1 root root 12288 Nov 30 09:01 virtual-mailbox-maps.db
-rw-r--r-- 1 root root 12288 Nov 30 09:01 virtual.db
```

These are the same permissions/ownership as on my (non-dockerized) mail server, which has been running smoothly for about a year. Also `postfix check` is happy with this as it doesn't raise any errors or warnings, and the container runs fine :smile:
